### PR TITLE
Squelch error when service is interrupted

### DIFF
--- a/src/main/scala/com/swoval/watchservice/CarbonAPI.scala
+++ b/src/main/scala/com/swoval/watchservice/CarbonAPI.scala
@@ -87,8 +87,10 @@ private class CFRunLoopThread extends Thread("WatchService") {
   override def run() = {
     runLoop // Need to touch this variable to set the RunLoop to this thread
     initLatch.countDown()
-    signalLatch.await()
-    CFRunLoopRun()
+    try {
+      signalLatch.await()
+      CFRunLoopRun()
+    } catch { case _: InterruptedException => /* service was shutdown */ }
   }
 }
 


### PR DESCRIPTION
If the service is stopped before any directories are registered, it
creates an unhandled InterruptedException. In practice, this happens
because of a bug in sbt (see https://github.com/sbt/sbt/pull/3790), but
I want to remove these warnings for current users of the plugin.