### PR TITLE
Fix another recursive bug

### DIFF
--- a/plugin/src/main/scala/com/swoval/watchservice/files/FileCache.scala
+++ b/plugin/src/main/scala/com/swoval/watchservice/files/FileCache.scala
@@ -151,7 +151,8 @@ object FileOptions {
   def apply(latency: Duration, flags: Flags.Create): FileOptions = {
     new MonitorOptions(latency, flags) with FileOptions
   }
-  lazy val default: FileOptions = FileOptions(10.milliseconds, new Flags.Create(Flags.Create.NoDefer).setFileEvents())
+  lazy val default: FileOptions =
+    FileOptions(10.milliseconds, new Flags.Create(Flags.Create.NoDefer).setFileEvents())
 }
 sealed trait DirectoryOptions extends Options
 object DirectoryOptions {


### PR DESCRIPTION
The base directories were still being traversed non-recursively when sbt
was getting the source list. The solution was to add an additional check
that files obtained while traversing the base directory are actually in
the base directory and not in a sub directory.