### PR TITLE
Don't reuse FileCache

### DIFF
--- a/files/jvm/src/main/scala/com/swoval/files/ExecutorServiceWrapper.scala
+++ b/files/jvm/src/main/scala/com/swoval/files/ExecutorServiceWrapper.scala
@@ -10,7 +10,9 @@ class ExecutorServiceWrapper(val s: ExecutorService) extends Executor {
   override def close(): Unit = {
     if (!s.isShutdown) {
       s.shutdownNow()
-      s.awaitTermination(5, TimeUnit.SECONDS)
+      try {
+        s.awaitTermination(5, TimeUnit.SECONDS)
+      } catch { case _: InterruptedException => }
     }
   }
 }

--- a/files/shared/src/main/scala/com/swoval/files/FileCache.scala
+++ b/files/shared/src/main/scala/com/swoval/files/FileCache.scala
@@ -13,11 +13,13 @@ trait FileCache extends AutoCloseable with Callbacks {
   def register(path: Path): Option[Directory]
 }
 
-class FileCacheImpl(options: Options) extends FileCache {
+class FileCacheImpl(options: Options, private[this] val directories: mutable.Set[Directory])
+    extends FileCache {
+  def this(options: Options) = this(options, mutable.Set.empty)
   private[this] val executor: Executor =
     platform.makeExecutor("com.swoval.files.FileCacheImpl.executor-thread")
   def list(path: Path, recursive: Boolean, filter: PathFilter): Seq[Path] =
-    lock
+    directories
       .synchronized {
         if (path.exists) {
           directories.find(path startsWith _.path) match {
@@ -33,7 +35,7 @@ class FileCacheImpl(options: Options) extends FileCache {
     if (path.exists) {
       val dir = Directory(path, _ => {})
       watcher.foreach(_.register(path))
-      lock.synchronized {
+      directories.synchronized {
         directories foreach { dir =>
           if (dir.path startsWith path) directories.remove(dir)
         }
@@ -45,9 +47,10 @@ class FileCacheImpl(options: Options) extends FileCache {
     }
   }
 
-  override def close(): Unit = {
+  override def close(): Unit = closeImpl()
+  protected def closeImpl(clearDirectoriesOnClose: Boolean = true): Unit = {
     watcher.foreach(_.close())
-    directories.clear()
+    if (clearDirectoriesOnClose) directories.clear()
     executor.close()
   }
 
@@ -59,34 +62,41 @@ class FileCacheImpl(options: Options) extends FileCache {
           case Seq(p) if p == path =>
             callback(FileWatchEvent(path, Modify))
           case Seq() =>
-            directories.find(path startsWith _.path) match {
-              case Some(dir) if path != dir.path =>
-                lock.synchronized(dir.add(path, isFile = !path.isDirectory, callback))
-              case _ =>
+            directories.synchronized {
+              directories.find(path startsWith _.path) match {
+                case Some(dir) if path != dir.path =>
+                  dir.add(path, isFile = !path.isDirectory, callback)
+                case _ =>
+              }
             }
           case Seq(_) =>
         }
       } else {
-        directories.find(path startsWith _.path) match {
-          case Some(dir) =>
-            if (dir.remove(path)) callback(FileWatchEvent(path, Delete))
-          case _ =>
+        directories.synchronized {
+          directories.find(path startsWith _.path) match {
+            case Some(dir) =>
+              if (dir.remove(path)) callback(FileWatchEvent(path, Delete))
+            case _ =>
+          }
         }
       }
   }
   private[this] val watcher = options.toWatcher(fileCallback, executor)
-  private[this] val directories: mutable.Set[Directory] = mutable.Set.empty
-  private[this] object lock
+  for { w <- watcher; dir <- directories } w.register(dir.path)
   override def toString = s"FileCache($options)"
 }
 
 object FileCache {
-  def apply(options: Options)(callback: Callback): FileCacheImpl = {
-    val cache: FileCacheImpl = new FileCacheImpl(options)
+  def apply(options: Options, directories: mutable.Set[Directory] = mutable.Set.empty)(
+      callback: Callback): FileCacheImpl = {
+    val cache: FileCacheImpl = new FileCacheImpl(options, directories)
     cache.addCallback(callback)
     cache
   }
-  lazy val default: FileCacheImpl = new FileCacheImpl(Options.default)
+  private[this] val directories: mutable.Set[Directory] = mutable.Set.empty
+  def default: FileCacheImpl = new FileCacheImpl(Options.default, directories) {
+    override def close(): Unit = closeImpl(clearDirectoriesOnClose = false)
+  }
 }
 
 sealed abstract class Options {

--- a/files/shared/src/test/scala/com/swoval/files/FileCacheTest.scala
+++ b/files/shared/src/test/scala/com/swoval/files/FileCacheTest.scala
@@ -92,6 +92,23 @@ object FileCacheTest extends TestSuite {
           }
         }
       }
+      'reuseDirectories - withTempDirectory { dir =>
+        val directory = Directory(dir)
+        val directories = mutable.Set(directory)
+        val latch = new CountDownLatch(1)
+        usingAsync(new FileCacheImpl(options, directories) {
+          override def close() = closeImpl(clearDirectoriesOnClose = false)
+        }) { c =>
+          c.addCallback(_ => latch.countDown())
+          withTempFile(dir) { f =>
+            latch.waitFor(DEFAULT_TIMEOUT) {
+              c.list(dir, recursive = true, _ => true) === Seq(f)
+              c.close()
+              directories.toSet === Set(directory)
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Previously the FileCache had been a global. This worked most of the
time but, when cross building, the current project is closed which
caused the global cache to be closed. Later attempts to list the files
from the cache would then throw an exception. The simplest fix is to
just change the FileCache default from a lazy val to a def. This does
mean, however, that every time we make a new cache, we have to
re-traverse the file system to clear it. To avoid this, we now pass in
the directory set as a parameter to the FileCacheImpl.

Fixes #42